### PR TITLE
fix: change dependencies from peer to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-gesture-handler": "^2.x",
+    "react-native-reanimated": "^3.x"
   },
   "workspaces": [
     "example"

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "react": "18.2.0",
     "react-native": "0.72.5",
     "react-native-builder-bob": "^0.20.0",
+    "react-native-gesture-handler": "^2.x",
+    "react-native-reanimated": "^3.x",
     "release-it": "^15.0.0",
     "typescript": "^5.0.2"
   },
@@ -76,9 +78,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*",
-    "react-native-gesture-handler": "^2.x",
-    "react-native-reanimated": "^3.x"
+    "react-native": "*"
   },
   "workspaces": [
     "example"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14821,6 +14821,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-native-gesture-handler@npm:^2.x":
+  version: 2.15.0
+  resolution: "react-native-gesture-handler@npm:2.15.0"
+  dependencies:
+    "@egjs/hammerjs": ^2.0.17
+    hoist-non-react-statics: ^3.3.0
+    invariant: ^2.2.4
+    lodash: ^4.17.21
+    prop-types: ^15.7.2
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 4db52e7b38b047bad677ed570a0ef4c2ddfc413bbbce5ed21f487c9d86c60588ee6b2c9f74bb842e5654284b0d1e6a8af81f68000e737d8a7f1e030b6d3fe6b6
+  languageName: node
+  linkType: hard
+
 "react-native-gesture-handler@npm:~2.12.0":
   version: 2.12.1
   resolution: "react-native-gesture-handler@npm:2.12.1"
@@ -14878,15 +14894,36 @@ __metadata:
     react: 18.2.0
     react-native: 0.72.5
     react-native-builder-bob: ^0.20.0
+    react-native-gesture-handler: ^2.x
+    react-native-reanimated: ^3.x
     release-it: ^15.0.0
     typescript: ^5.0.2
   peerDependencies:
     react: "*"
     react-native: "*"
-    react-native-gesture-handler: ^2.x
-    react-native-reanimated: ^3.x
   languageName: unknown
   linkType: soft
+
+"react-native-reanimated@npm:^3.x":
+  version: 3.6.2
+  resolution: "react-native-reanimated@npm:3.6.2"
+  dependencies:
+    "@babel/plugin-transform-object-assign": ^7.16.7
+    "@babel/preset-typescript": ^7.16.7
+    convert-source-map: ^2.0.0
+    invariant: ^2.2.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+    "@babel/plugin-proposal-nullish-coalescing-operator": ^7.0.0-0
+    "@babel/plugin-proposal-optional-chaining": ^7.0.0-0
+    "@babel/plugin-transform-arrow-functions": ^7.0.0-0
+    "@babel/plugin-transform-shorthand-properties": ^7.0.0-0
+    "@babel/plugin-transform-template-literals": ^7.0.0-0
+    react: "*"
+    react-native: "*"
+  checksum: 0a5030ec7d66603bdb1777fb9a37f6621c7c329b47101596d882d0dd526fe1ed34f4088635aacb9d44988bdbc6fe5b792145fc44eafaceb080b7a8c7ddd69eff
+  languageName: node
+  linkType: hard
 
 "react-native-reanimated@npm:~3.3.0":
   version: 3.3.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -14901,6 +14901,8 @@ __metadata:
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-gesture-handler: ^2.x
+    react-native-reanimated: ^3.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Fixes #11 

This change fixes the issue for a developer trying to make projects to the project. I'm unsure if this change would affect projects that depend on this library, and what those effects would be.