### PR TITLE
feat: return information of scale and translation on `onTranslationFinished` listener

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -300,6 +300,9 @@ export default forwardRef(function PanPinchView(
             y: boundedY,
             clampedX,
             clampedY,
+            scale: scale.value,
+            translateX: offset.x.value + translation.x.value,
+            translateY: offset.y.value + translation.y.value,
           });
         }
 


### PR DESCRIPTION
On the project I'm working on now, I had to add these additional fields so that I can calculate the exact viewport where the user zoomed the image.
I'm raising this PR in case it's useful for some other project.